### PR TITLE
Refactor/update user schema

### DIFF
--- a/backend/requests/userRequests/createUsers.test.rest
+++ b/backend/requests/userRequests/createUsers.test.rest
@@ -5,7 +5,7 @@ Content-Type: application/json
     "username": "Test 2",
     "password": "9090pass",
     "email": "test2@gmail.com",
-    "tipo_user": "usuario"
+    "tipo_user": "user"
 }
 
 ###
@@ -17,7 +17,7 @@ Content-Type: application/json
 {
     "password": "9090pass",
     "email": "joel2@test.com",
-    "tipo_user": "usuario"
+    "tipo_user": "user"
 }
 
 ###
@@ -29,7 +29,7 @@ Content-Type: application/json
     "username": "",
     "password": "9090pass",
     "email": "joel2@test.com",
-    "tipo_user": "usuario"
+    "tipo_user": "user"
 }
 
 ###
@@ -41,7 +41,7 @@ Content-Type: application/json
     "username": "Joel2",
     "password": "",
     "email": "joel2@test.com",
-    "tipo_user": "usuario"
+    "tipo_user": "user"
 }
 
 ###
@@ -52,7 +52,7 @@ Content-Type: application/json
 {
     "username": "Joel2",
     "email": "joel2@test.com",
-    "tipo_user": "usuario"
+    "tipo_user": "user"
 }
 
 ###
@@ -64,7 +64,7 @@ Content-Type: application/json
     "username": "Joel2",
     "password": "9090pass",
     "email": "",
-    "tipo_user": "usuario"
+    "tipo_user": "user"
 }
 
 ###
@@ -75,7 +75,7 @@ Content-Type: application/json
 {
     "username": "Joel2",
     "password": "9090pass",
-    "tipo_user": "usuario"
+    "tipo_user": "user"
 }
 
 ###

--- a/backend/requests/userRequests/updateUser.test.rest
+++ b/backend/requests/userRequests/updateUser.test.rest
@@ -1,11 +1,12 @@
-PUT http://localhost:3001/api/users/update/7eef03ad-2757-4b7c-91ca-412731359067
+PUT http://localhost:3001/api/users/update/ac1ac77f-ad99-463d-9fcc-368f30c9b0b0
 Content-Type: application/json
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VybmFtZSI6IkpvZWwgdGVzdCIsImlkZW50aWZpZXIiOiI3NDlhYTYyNC02NWRhLTQ0ZDQtYTNjZC1kNTYxNjdkZTFhNWIiLCJpYXQiOjE3MTQ3OTIwNDB9.QvmBCboIUrDhHrsNey-B_yua96BcTj3NulX2ts1E2Sw
 
 {
-    "username": "Joel",
+    "username": "Test 3",
     "password": "9090pass",
-    "email": "joelnew@test.com",
-    "tipo_user": "usuario"
+    "email": "test3@gmail.com",
+    "tipo_user": "user"
 }
 
 # Se deben mandar todos los campos para actualizar un usuario!

--- a/backend/schemas/userSchema.ts
+++ b/backend/schemas/userSchema.ts
@@ -33,7 +33,7 @@ const userSchema = z.object({
             message: "El número debe ser de 9 caracteres.",
         })
         .optional(),
-    tipo_user: z.enum(["usuario", "administrador"], {
+    tipo_user: z.enum(["user", "admin"], {
         errorMap: () => ({
             message: "Debes seleccionar un tipo de usuario válido.",
             required_error: "Debes señalar el tipo de usuario.",


### PR DESCRIPTION
# Titulo

Se actualizó el esquema de los usuarios para que acepte los strings 'user' y 'admin'.

## ¿Por qué se hizo? 🥸

Asegurar consistencia entre la base de datos y la aplicación.

## ¿Qué se hizo? 🪚

Se actualizó el esquema utilizado para verificar que los datos son correctos para que acepten los strings 'user' y 'admin'.
Los 4 usuarios existentes en la base de datos de desarrollo ya están actualizados; ahora el campo de tipo_usuario contiene el string 'user'.

![image_2024-05-03_231740860](https://github.com/IgnacioBarraza/Proyecto_IngenieriaSoftware_SID/assets/135843731/69bb9c39-b95f-4bd8-8fee-da86cce7ac5f)


## ¿Cómo se prueba esto? 🧪

Mandar una request a POST http://localhost:3001/api/users/new (no olvidar el token generado por el login), e indicar que el tipo de usuario es 'user' (o 'admin'). Debería funcionar sin problemas.
