### PR TITLE
refactor: moving get routes out of auth

### DIFF
--- a/backend/app.ts
+++ b/backend/app.ts
@@ -19,6 +19,7 @@ import verifyToken from './middleware/verifyToken'
 // Utils:
 import { rateLimiter } from './utils/rate-limiter'
 import { slowDownLimiter } from './utils/slow-down'
+import dataRouter from './routes/getData'
 
 const app = express()
 
@@ -29,6 +30,7 @@ app.use(rateLimiter)
 app.use(slowDownLimiter)
 
 app.use('/api/login', loginRouter)
+app.use('/api/get', dataRouter)
 
 app.use('', verifyToken)
 

--- a/backend/routes/galleryRouter.ts
+++ b/backend/routes/galleryRouter.ts
@@ -7,22 +7,6 @@ import { validateImage, validateUpdateImage } from '../schemas/gallerySchema'
 
 const galleryRouter = express.Router()
 
-galleryRouter.get('/', async (req, res) => {
-    const connection = connect()
-
-    try {
-        const [row, fields] = await connection.query(`SELECT * FROM gallery`)
-        return res.status(200).json(row)
-    } catch (error) {
-        // console.log(error)
-        return res.status(500).json({ message: 'Hubo un error en el servidor. Intente más tarde.' })
-    } finally {
-        if (connection) {
-            connection.end()
-        }
-    }   
-})
-
 galleryRouter.post('/new', async (req, res) => {
     const connection = connect()
 

--- a/backend/routes/getData.ts
+++ b/backend/routes/getData.ts
@@ -1,0 +1,56 @@
+import express from 'express'
+
+import { connect } from '../utils/db'
+
+const dataRouter = express.Router()
+
+dataRouter.get('/services', async (req, res) => {
+    const connection = connect()
+
+    try {
+        const [row, fields] = await connection.query(`SELECT * FROM servicios`)
+        return res.status(200).json(row)
+    } catch (error) {
+        // console.log(error)
+        return res.status(500).json({ message: 'Hubo un error con el servidor. Intente más tarde.s' })
+    } finally {
+        if (connection) {
+            connection.end()
+        }
+    }
+})
+
+dataRouter.get('/gallery', async (req, res) => {
+    const connection = connect()
+
+    try {
+        const [row, fields] = await connection.query(`SELECT * FROM gallery`)
+        return res.status(200).json(row)
+    } catch (error) {
+        // console.log(error)
+        return res.status(500).json({ message: 'Hubo un error en el servidor. Intente más tarde.' })
+    } finally {
+        if (connection) {
+            connection.end()
+        }
+    }
+})
+
+dataRouter.get('/inventory', async (req, res) => {
+    const connection = connect()
+
+    try {
+        const [row, fields] = await connection.query(`SELECT * FROM inventario`)
+
+        res.status(200).json(row)
+    } catch (error) {
+        // console.log(error)
+        res.status(500).json({ message: 'Hubo un error intentando obtener los artículos del inventario.' })
+    } finally {
+        if (connection) {
+            connection.end()
+        }
+    }
+})
+
+export default dataRouter

--- a/backend/routes/inventoryRouter.ts
+++ b/backend/routes/inventoryRouter.ts
@@ -7,23 +7,6 @@ import authorizeRole from '../middleware/authorizeRole'
 
 const inventoryRouter = express.Router()
 
-inventoryRouter.get('/', async (req, res) => {
-    const connection = connect()
-
-    try {
-        const [row, fields] = await connection.query(`SELECT * FROM inventario`)
-
-        res.status(200).json(row)
-    } catch (error) {
-        // console.log(error)
-        res.status(500).json({ message: 'Hubo un error intentando obtener los artículos del inventario.' })
-    } finally {
-        if (connection) {
-            connection.end()
-        }
-    }
-})
-
 inventoryRouter.post('/new', authorizeRole, async (req, res) => {
     const connection = connect()
 

--- a/backend/routes/serviceRouter.ts
+++ b/backend/routes/serviceRouter.ts
@@ -7,22 +7,6 @@ import { validateService, validateUpdateService } from '../schemas/serviceSchema
 
 const serviceRouter = express.Router()
 
-serviceRouter.get('/', async (req, res) => {
-    const connection = connect()
-
-    try {
-        const [row, fields] = await connection.query(`SELECT * FROM servicios`)
-        return res.status(200).json(row)
-    } catch (error) {
-        // console.log(error)
-        return res.status(500).json({ message: 'Hubo un error con el servidor. Intente más tarde.s' })
-    } finally {
-        if (connection) {
-            connection.end()
-        }
-    }
-})
-
 serviceRouter.post('/new', async (req, res) => {
     const connection = connect()
     


### PR DESCRIPTION
# Acceder a rutas GET para servicios, galería e inventario

## ¿Por qué se hizo? 🥸

🔗 [Tarea Jira](https://alumnos-team-nx2zqgkh.atlassian.net/jira/software/projects/KAN/boards/1?selectedIssue=KAN-86)

## ¿Qué se hizo? 🪚

Se movieron las rutas tipo GET para las tablas de `servicios`, `gallery` e `inventario` a una ruta que no necesita de tokens de autentificación.

## ¿Cómo se prueba esto? 🧪

1. `npm run dev` en la carpeta backend.
2. Hacer una petición GET a `http://localhost:3000/api/get/services` sin poner el token en los headers. Debería devolver un array de objetos con datos de la base de datos.
3. Hacer una petición GET a `http://localhost:3000/api/get/gallery` sin poner el token en los headers, debería devolver un array vacío (porque no hay datos en esa tabla). De todas maneras, si se agregan datos, deberían aparecer ahí.
4. Hacer una petición GET a `http://localhost:3000/api/get/inventory` sin agregar el token. Igual que en la anterior, debería devolver un array vacío porque no hay datos en esa tabla, y si se agregan datos, deberían aparecer ahí.