### PR TITLE
Fix/add equipment data verification

### DIFF
--- a/backend/schemas/equipmentSchema.ts
+++ b/backend/schemas/equipmentSchema.ts
@@ -1,21 +1,21 @@
-import { object, z } from 'zod'
+import { z } from 'zod'
 
 const itemSchema = z.object({
     nombre_equipo: z
         .string({
             required_error: 'Debes ingresar un nombre para el equipo!',
-            invalid_type_error: 'Ingresa un nombre válido.S'
+            invalid_type_error: 'Ingresa un nombre válido.'
         })
-        .refine(value => /^.{0,90}$/.test(value), {
-            message: 'Por favor, ingresa un nombre más corto!'
+        .refine(value => /^.{5,90}$/.test(value), {
+            message: 'Puedes ingresar desde 5 hasta 90 caracteres para el nombre del equipo!'
         }),
     tipo_equipo: z
         .string({
             required_error: 'Debes indicar el tipo de equipo.',
             invalid_type_error: 'Ingresa un tipo de equipo válido!'
         })
-        .refine(value => /^.{0,90}$/.test(value), {
-            message: 'Puedes ingresar hasta 90 caracteres!'
+        .refine(value => /^.{5,90}$/.test(value), {
+            message: 'Puedes ingresar desde 5 a 90 caracteres para el tipo de equipo!'
         }),
     id_servicios: z
         .string({
@@ -28,10 +28,10 @@ const updateItemSchema = z.object({
     nombre_equipo: z
         .string({
             required_error: 'Debes ingresar un nombre para el equipo!',
-            invalid_type_error: 'Ingresa un nombre válido.S'
+            invalid_type_error: 'Ingresa un nombre válido.'
         })
-        .refine(value => /^.{0,90}$/.test(value), {
-            message: 'Por favor, ingresa un nombre más corto!'
+        .refine(value => /^.{5,90}$/.test(value), {
+            message: 'Puedes ingresar desde 5 hasta 90 caracteres para el nombre del equipo!'
         })
         .optional(),
     tipo_equipo: z
@@ -39,8 +39,8 @@ const updateItemSchema = z.object({
             required_error: 'Debes indicar el tipo de equipo.',
             invalid_type_error: 'Ingresa un tipo de equipo válido!'
         })
-        .refine(value => /^.{0,90}$/.test(value), {
-            message: 'Puedes ingresar hasta 90 caracteres!'
+        .refine(value => /^.{5,90}$/.test(value), {
+            message: 'Puedes ingresar desde 5 a 90 caracteres para el tipo de equipo!'
         })
         .optional(),
     id_servicios: z

--- a/frontend/src/shared/tools.tsx
+++ b/frontend/src/shared/tools.tsx
@@ -18,18 +18,20 @@ export const Tools = () => {
   const [toolsItems, setToolsItems] = useState<Equipment[]>([]);
 
   const removeItem = async (id_tool: string) => {
-    const updateItems = toolsItems.filter(tool => tool.id_equipo !== id_tool)
-    try {
-      // Call the backend service to delete the tool
-      const res = await deleteEquipment(id_tool, userToken);
-      const {status, data} = res
-      if (status === 200) {
-        alert(data.message)
-        setToolsItems(updateItems);
-        setToolsData(updateItems);
-      }
-    } catch (error) {
-      console.error("Error deleting equipment:", error);
+    if (confirm('¿Estás seguro que quieres eliminar este equipo?')) {
+        const updateItems = toolsItems.filter(tool => tool.id_equipo !== id_tool)
+        try {
+          // Call the backend service to delete the tool
+          const res = await deleteEquipment(id_tool, userToken);
+          const {status, data} = res
+          if (status === 200) {
+            alert(data.message)
+            setToolsItems(updateItems);
+            setToolsData(updateItems);
+          }
+        } catch (error) {
+          console.error("Error deleting equipment:", error);
+        }
     }
   };
 

--- a/frontend/src/shared/toolscomponents/uploadToolsModal.tsx
+++ b/frontend/src/shared/toolscomponents/uploadToolsModal.tsx
@@ -33,6 +33,16 @@ export const UploadToolsModal = ({ handleInterface, services, addTool }) => {
   }
 
   const uploadTool = async () => {
+    if (selectedServices.length === 0) {
+        alert('Selecciona uno más servicios asociados al equipo!')
+        return
+    } else if (tool.toolName === '') {
+        alert('Ingresa un nombre para el equipo!')
+        return
+    } else if (tool.toolType === '') {
+        alert('Debes ingresar el tipo de equipo!')
+        return
+    }
     const newTool: CreateEquipment = {
       nombre_equipo: tool.toolName,
       tipo_equipo: tool.toolType,

--- a/frontend/src/shared/toolscomponents/uploadToolsModal.tsx
+++ b/frontend/src/shared/toolscomponents/uploadToolsModal.tsx
@@ -39,6 +39,12 @@ export const UploadToolsModal = ({ handleInterface, services, addTool }) => {
     } else if (tool.toolName === '') {
         alert('Ingresa un nombre para el equipo!')
         return
+    } else if (tool.toolName.length < 5 || tool.toolName.length > 90) {
+        alert('El nombre del equipo debe tener entre 5 y 90 carácteres!')
+        return
+    } else if (tool.toolType.length < 5 || tool.toolType.length > 90) {
+        alert('El tipo de equipo ingresado debe contener entre 5 y 90 carácteres!')
+        return
     } else if (tool.toolType === '') {
         alert('Debes ingresar el tipo de equipo!')
         return


### PR DESCRIPTION
# Agregar verificaciones al crear un nuevo equipo

## ¿Por qué se hizo? 🥸

🔗 [issue del jira](https://alumnos-team-nx2zqgkh.atlassian.net/jira/software/projects/KAN/boards/1?selectedIssue=KAN-100)

## ¿Qué se hizo? 🪚

En el backend se actualizaron los esquemas que validan los datos, ahora el nombre y el tipo de equipo deben contener entre `5 y 90 caracteres` cada uno. Para el frontend, se agregaron alerts para cuando se intenta crear un equipo pero no se seleccionan servicios, no se agrega un nombre o no se indica el tipo de equipo.
También se agregó un `confirm()` cuando se hace click en eliminar un servicio.
Para hacer las validaciones en el frontend de que se hayan seleccionado servicios o el tema del length del toolName y toolType utilicé muchos ifs, no sé si a alguien se le ocurra otra manera de hacerlo.


## ¿Cómo se prueba esto? 🧪

1. `npm run dev` en el backend y en el frontend.
2. Iniciar sesión con una cuenta de administrador.
3. Ir al apartado de equipos y seleccionar 'Añadir equipo'.
4. Intentar agregar un equipo sin seleccionar servicios, sin añadir un nombre o sin indicar el tipo de equipo. Esas 3 situaciones deberían abrir un alert con un mensaje distinto.
5. Intentar eliminar un servicio, debería aparecer una ventana de tipo `confirm` con dos opciones. Si se hace click en OK se debería eliminar el equipo, si se hace click en cancelar no se debería agregar nada.